### PR TITLE
Fix/42 delete white space

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <service
-            android:name=".service.FirebaseMessagingService"
+            android:name=".service.NotTodoFCMService"
             android:exported="true">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />

--- a/app/src/main/java/kr/co/nottodo/MainActivity.kt
+++ b/app/src/main/java/kr/co/nottodo/MainActivity.kt
@@ -7,11 +7,12 @@ import androidx.fragment.app.commit
 import com.google.android.material.shape.CornerFamily
 import com.google.android.material.shape.MaterialShapeDrawable
 import kr.co.nottodo.databinding.ActivityMainBinding
+import kr.co.nottodo.interfaces.MainInterface
 import kr.co.nottodo.presentation.achieve.AchieveFragment
 import kr.co.nottodo.presentation.home.view.HomeFragment
 import kr.co.nottodo.presentation.mypage.view.MyPageFragment
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : AppCompatActivity(), MainInterface {
     lateinit var binding: ActivityMainBinding
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -52,6 +53,14 @@ class MainActivity : AppCompatActivity() {
     private fun changeFragment(fragment: Fragment) {
         supportFragmentManager.commit {
             replace(R.id.fcv_main, fragment)
+        }
+    }
+
+    override fun setActivityBackgroundColorBasedOnFragment(thisFragment: Fragment) {
+        when (thisFragment) {
+            is HomeFragment -> binding.root.setBackgroundColor(getColor(R.color.bg_f2f2f7))
+            is AchieveFragment -> binding.root.setBackgroundColor(getColor(R.color.black))
+            is MyPageFragment -> binding.root.setBackgroundColor(getColor(R.color.black))
         }
     }
 

--- a/app/src/main/java/kr/co/nottodo/MainActivity.kt
+++ b/app/src/main/java/kr/co/nottodo/MainActivity.kt
@@ -53,6 +53,12 @@ class MainActivity : AppCompatActivity() {
         supportFragmentManager.commit {
             replace(R.id.fcv_main, fragment)
         }
+
+        when (fragment) {
+            is HomeFragment -> binding.root.setBackgroundColor(getColor(R.color.bg_f2f2f7))
+            is AchieveFragment -> binding.root.setBackgroundColor(getColor(R.color.black))
+            is MyPageFragment -> binding.root.setBackgroundColor(getColor(R.color.black))
+        }
     }
 
     companion object {

--- a/app/src/main/java/kr/co/nottodo/MainActivity.kt
+++ b/app/src/main/java/kr/co/nottodo/MainActivity.kt
@@ -53,12 +53,6 @@ class MainActivity : AppCompatActivity() {
         supportFragmentManager.commit {
             replace(R.id.fcv_main, fragment)
         }
-
-        when (fragment) {
-            is HomeFragment -> binding.root.setBackgroundColor(getColor(R.color.bg_f2f2f7))
-            is AchieveFragment -> binding.root.setBackgroundColor(getColor(R.color.black))
-            is MyPageFragment -> binding.root.setBackgroundColor(getColor(R.color.black))
-        }
     }
 
     companion object {

--- a/app/src/main/java/kr/co/nottodo/MainActivity.kt
+++ b/app/src/main/java/kr/co/nottodo/MainActivity.kt
@@ -7,12 +7,12 @@ import androidx.fragment.app.commit
 import com.google.android.material.shape.CornerFamily
 import com.google.android.material.shape.MaterialShapeDrawable
 import kr.co.nottodo.databinding.ActivityMainBinding
-import kr.co.nottodo.interfaces.MainInterface
+import kr.co.nottodo.listeners.OnFragmentChangedListener
 import kr.co.nottodo.presentation.achieve.AchieveFragment
 import kr.co.nottodo.presentation.home.view.HomeFragment
 import kr.co.nottodo.presentation.mypage.view.MyPageFragment
 
-class MainActivity : AppCompatActivity(), MainInterface {
+class MainActivity : AppCompatActivity(), OnFragmentChangedListener {
     lateinit var binding: ActivityMainBinding
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/kr/co/nottodo/interfaces/MainInterface.kt
+++ b/app/src/main/java/kr/co/nottodo/interfaces/MainInterface.kt
@@ -1,0 +1,7 @@
+package kr.co.nottodo.interfaces
+
+import androidx.fragment.app.Fragment
+
+interface MainInterface {
+    fun setActivityBackgroundColorBasedOnFragment(thisFragment: Fragment)
+}

--- a/app/src/main/java/kr/co/nottodo/listeners/OnFragmentChangedListener.kt
+++ b/app/src/main/java/kr/co/nottodo/listeners/OnFragmentChangedListener.kt
@@ -1,7 +1,7 @@
-package kr.co.nottodo.interfaces
+package kr.co.nottodo.listeners
 
 import androidx.fragment.app.Fragment
 
-interface MainInterface {
+interface OnFragmentChangedListener {
     fun setActivityBackgroundColorBasedOnFragment(thisFragment: Fragment)
 }

--- a/app/src/main/java/kr/co/nottodo/presentation/achieve/AchieveFragment.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/achieve/AchieveFragment.kt
@@ -1,17 +1,25 @@
 package kr.co.nottodo.presentation.achieve
 
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import kr.co.nottodo.databinding.FragmentAchieveBinding
-import kr.co.nottodo.interfaces.MainInterface
+import kr.co.nottodo.listeners.OnFragmentChangedListener
 
 
 class AchieveFragment : Fragment() {
     private var _binding: FragmentAchieveBinding? = null
     private val binding: FragmentAchieveBinding get() = requireNotNull(_binding)
+    private var onFragmentChangedListener: OnFragmentChangedListener? = null
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        onFragmentChangedListener = context as? OnFragmentChangedListener
+            ?: throw TypeCastException("context can not cast as OnFragmentChangedListener")
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -22,12 +30,14 @@ class AchieveFragment : Fragment() {
         return binding.root
     }
 
-    private fun setActivityBackgroundColor() {
-        (context as MainInterface).setActivityBackgroundColorBasedOnFragment(this)
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        setActivityBackgroundColor()
+    }
+
+    private fun setActivityBackgroundColor() {
+        onFragmentChangedListener?.setActivityBackgroundColorBasedOnFragment(this@AchieveFragment)
+            ?: throw NullPointerException("onFragmentChangedListener is null")
     }
 
     override fun onDestroyView() {
@@ -35,4 +45,8 @@ class AchieveFragment : Fragment() {
         super.onDestroyView()
     }
 
+    override fun onDetach() {
+        onFragmentChangedListener = null
+        super.onDetach()
+    }
 }

--- a/app/src/main/java/kr/co/nottodo/presentation/achieve/AchieveFragment.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/achieve/AchieveFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import kr.co.nottodo.databinding.FragmentAchieveBinding
+import kr.co.nottodo.interfaces.MainInterface
 
 
 class AchieveFragment : Fragment() {
@@ -14,10 +15,15 @@ class AchieveFragment : Fragment() {
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
+        savedInstanceState: Bundle?,
+    ): View {
+        setActivityBackgroundColor()
         _binding = FragmentAchieveBinding.inflate(layoutInflater, container, false)
         return binding.root
+    }
+
+    private fun setActivityBackgroundColor() {
+        (context as MainInterface).setActivityBackgroundColorBasedOnFragment(this)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/kr/co/nottodo/presentation/home/view/HomeFragment.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/home/view/HomeFragment.kt
@@ -1,5 +1,6 @@
 package kr.co.nottodo.presentation.home.view
 
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -7,35 +8,38 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import kr.co.nottodo.data.model.ResponseHomeDaily
 import kr.co.nottodo.databinding.FragmentHomeBinding
-import kr.co.nottodo.interfaces.MainInterface
+import kr.co.nottodo.listeners.OnFragmentChangedListener
 
 class HomeFragment : Fragment() {
     private var _binding: FragmentHomeBinding? = null
     private val binding: FragmentHomeBinding
         get() = requireNotNull(_binding)
-    private lateinit var homeAdpater: HomeAdpater
+    private lateinit var homeAdapter: HomeAdpater
+    private var onFragmentChangedListener: OnFragmentChangedListener? = null
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        onFragmentChangedListener = context as? OnFragmentChangedListener
+            ?: throw TypeCastException("context can not cast as OnFragmentChangedListener")
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View {
-        setActivityBackgroundColor()
         _binding = FragmentHomeBinding.inflate(layoutInflater, container, false)
         return binding.root
-    }
-
-    private fun setActivityBackgroundColor() {
-        (context as MainInterface).setActivityBackgroundColorBasedOnFragment(this)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initAdapter()
+        setActivityBackgroundColor()
     }
 
     private fun initAdapter() {
-        homeAdpater = HomeAdpater(::menuItemClick, ::todoItemClick)
-        binding.rvHomeTodoList.adapter = homeAdpater
+        homeAdapter = HomeAdpater(::menuItemClick, ::todoItemClick)
+        binding.rvHomeTodoList.adapter = homeAdapter
         val todoList = listOf(
             ResponseHomeDaily(
                 missions = 1,
@@ -59,7 +63,12 @@ class HomeFragment : Fragment() {
                 situation = "잉"
             ),
         )
-        homeAdpater.submitList(todoList)
+        homeAdapter.submitList(todoList)
+    }
+
+    private fun setActivityBackgroundColor() {
+        onFragmentChangedListener?.setActivityBackgroundColorBasedOnFragment(this@HomeFragment)
+            ?: throw NullPointerException("onFragmentChangedListener is null")
     }
 
     private fun menuItemClick(index: Long) {
@@ -74,5 +83,10 @@ class HomeFragment : Fragment() {
     override fun onDestroyView() {
         _binding = null
         super.onDestroyView()
+    }
+
+    override fun onDetach() {
+        onFragmentChangedListener = null
+        super.onDetach()
     }
 }

--- a/app/src/main/java/kr/co/nottodo/presentation/home/view/HomeFragment.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/home/view/HomeFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import kr.co.nottodo.data.model.ResponseHomeDaily
 import kr.co.nottodo.databinding.FragmentHomeBinding
+import kr.co.nottodo.interfaces.MainInterface
 
 class HomeFragment : Fragment() {
     private var _binding: FragmentHomeBinding? = null
@@ -18,8 +19,13 @@ class HomeFragment : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View {
+        setActivityBackgroundColor()
         _binding = FragmentHomeBinding.inflate(layoutInflater, container, false)
         return binding.root
+    }
+
+    private fun setActivityBackgroundColor() {
+        (context as MainInterface).setActivityBackgroundColorBasedOnFragment(this)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/kr/co/nottodo/presentation/mypage/view/MyPageFragment.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/mypage/view/MyPageFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import kr.co.nottodo.databinding.FragmentMyPageBinding
+import kr.co.nottodo.interfaces.MainInterface
 
 class MyPageFragment : Fragment() {
     private var _binding: FragmentMyPageBinding? = null
@@ -16,8 +17,13 @@ class MyPageFragment : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View {
+        setActivityBackgroundColor()
         _binding = FragmentMyPageBinding.inflate(layoutInflater, container, false)
         return binding.root
+    }
+
+    private fun setActivityBackgroundColor() {
+        (context as MainInterface).setActivityBackgroundColorBasedOnFragment(this)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/kr/co/nottodo/presentation/mypage/view/MyPageFragment.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/mypage/view/MyPageFragment.kt
@@ -1,37 +1,51 @@
 package kr.co.nottodo.presentation.mypage.view
 
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import kr.co.nottodo.databinding.FragmentMyPageBinding
-import kr.co.nottodo.interfaces.MainInterface
+import kr.co.nottodo.listeners.OnFragmentChangedListener
 
 class MyPageFragment : Fragment() {
     private var _binding: FragmentMyPageBinding? = null
     private val binding: FragmentMyPageBinding
         get() = requireNotNull(_binding)
+    private var onFragmentChangedListener: OnFragmentChangedListener? = null
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        onFragmentChangedListener = context as? OnFragmentChangedListener
+            ?: throw TypeCastException("context can not cast as OnFragmentChangedListener")
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View {
-        setActivityBackgroundColor()
         _binding = FragmentMyPageBinding.inflate(layoutInflater, container, false)
         return binding.root
     }
 
-    private fun setActivityBackgroundColor() {
-        (context as MainInterface).setActivityBackgroundColorBasedOnFragment(this)
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        setActivityBackgroundColor()
+    }
+
+    private fun setActivityBackgroundColor() {
+        onFragmentChangedListener?.setActivityBackgroundColorBasedOnFragment(this@MyPageFragment)
+            ?: throw NullPointerException("onFragmentChangedListener is null")
     }
 
     override fun onDestroyView() {
         _binding = null
         super.onDestroyView()
+    }
+
+    override fun onDetach() {
+        onFragmentChangedListener = null
+        super.onDetach()
     }
 }


### PR DESCRIPTION
## 👻 작업한 내용
### 바텀 네비게이션에서 윗 부분을 둥글게 처리하니, 그 뒤의 흰색 여백이 거슬려서 제거
- [x] 홈 프래그먼트에서 여백이 안 보이는가?
- [x] 성취 프래그먼트에서 여백이 안 보이는가?
- [x] 내정보 프래그먼트에서 여백이 안 보이는가?
## 🎤 PR Point
맨 처음엔 MainActivity에서 해당 로직을 수행하였는데, MainActivity에서 ChangeFragment를 실행할 때 해당 로직이 같이 수행되어 먼저 backgroundcolor가 변하고, Fragment가 들어와 딜레이가 발생했습니다.

따라서 해당 로직을 인터페이스에 생성, MainActivity에서 구현, Fragment에서 사용하여 딜레이를 제거하였습니다.

아직 미숙한 interface를 써서 코드 한 번씩 봐주시면 감사베리머치
## 📸 스크린샷
<img src="https://github.com/DO-NOTTO-DO/AOS-NOTTODO/assets/108331578/104a2015-765b-48f4-9b90-eb5b2c3113fd" width="70%" height="70%"/>


## 📮 관련 이슈

- Resolved: #42 
