### PR TITLE
Fix/58 kakao social login

### DIFF
--- a/app/src/main/java/kr/co/nottodo/data/remote/api/TokenInterceptor.kt
+++ b/app/src/main/java/kr/co/nottodo/data/remote/api/TokenInterceptor.kt
@@ -1,6 +1,7 @@
 package kr.co.nottodo.data.remote.api
 
-import kr.co.nottodo.BuildConfig
+import kr.co.nottodo.data.local.SharedPreferences.getString
+import kr.co.nottodo.presentation.login.view.LoginActivity.Companion.USER_TOKEN
 import okhttp3.Interceptor
 import okhttp3.Response
 
@@ -10,7 +11,7 @@ class TokenInterceptor : Interceptor {
         val tokenAddedRequest = originalRequest.newBuilder()
             .header(
                 "Authorization",
-                BuildConfig.ANDROID_TOKEN
+                getString(USER_TOKEN) ?: ""
             )
             .build()
         return chain.proceed(tokenAddedRequest)

--- a/app/src/main/java/kr/co/nottodo/data/remote/api/TokenService.kt
+++ b/app/src/main/java/kr/co/nottodo/data/remote/api/TokenService.kt
@@ -4,8 +4,12 @@ import kr.co.nottodo.data.remote.model.RequestTokenDto
 import kr.co.nottodo.data.remote.model.ResponseTokenDto
 import retrofit2.http.Body
 import retrofit2.http.POST
+import retrofit2.http.Path
 
 interface TokenService {
-    @POST("auth")
-    suspend fun getToken(@Body request: RequestTokenDto): ResponseTokenDto
+    @POST("auth/login/{social}")
+    suspend fun getToken(
+        @Path("social") social: String,
+        @Body request: RequestTokenDto,
+    ): ResponseTokenDto
 }

--- a/app/src/main/java/kr/co/nottodo/data/remote/model/TokenDto.kt
+++ b/app/src/main/java/kr/co/nottodo/data/remote/model/TokenDto.kt
@@ -6,7 +6,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class RequestTokenDto(
     @SerialName("socialToken") val socialToken: String,
-    @SerialName("socialType") val socialType: String,
     @SerialName("fcmToken") val fcmToken: String,
 )
 
@@ -16,8 +15,7 @@ data class ResponseTokenDto(
     @SerialName("success") val success: String,
     @SerialName("message") val message: String,
     @SerialName("data") val data: AccessToken,
-
-    ) {
+) {
     @Serializable
     data class AccessToken(
         @SerialName("accessToken") val accessToken: String,

--- a/app/src/main/java/kr/co/nottodo/presentation/login/view/LoginActivity.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/login/view/LoginActivity.kt
@@ -9,6 +9,7 @@ import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
 import com.kakao.sdk.user.UserApiClient
 import kr.co.nottodo.MainActivity
+import kr.co.nottodo.data.local.SharedPreferences
 import kr.co.nottodo.databinding.ActivityLoginBinding
 import kr.co.nottodo.presentation.login.viewmodel.LoginViewModel
 import kr.co.nottodo.util.showToast
@@ -35,6 +36,7 @@ class LoginActivity : AppCompatActivity() {
     private fun observeGetTokenResult() {
         viewModel.getTokenResult.observe(this) {
             startActivity(Intent(this, MainActivity::class.java))
+            SharedPreferences.setString(USER_TOKEN, it.data.accessToken)
             if (!isFinishing) finish()
         }
         viewModel.getErrorResult.observe(this) {
@@ -88,5 +90,6 @@ class LoginActivity : AppCompatActivity() {
 
     companion object {
         const val KAKAO: String = "KAKAO"
+        const val USER_TOKEN = "USER_TOKEN"
     }
 }

--- a/app/src/main/java/kr/co/nottodo/presentation/login/view/LoginActivity.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/login/view/LoginActivity.kt
@@ -9,7 +9,6 @@ import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
 import com.kakao.sdk.user.UserApiClient
 import kr.co.nottodo.MainActivity
-import kr.co.nottodo.data.remote.model.RequestTokenDto
 import kr.co.nottodo.databinding.ActivityLoginBinding
 import kr.co.nottodo.presentation.login.viewmodel.LoginViewModel
 import kr.co.nottodo.util.showToast
@@ -36,7 +35,7 @@ class LoginActivity : AppCompatActivity() {
     private fun observeGetTokenResult() {
         viewModel.getTokenResult.observe(this) {
             startActivity(Intent(this, MainActivity::class.java))
-            finish()
+            if (!isFinishing) finish()
         }
         viewModel.getErrorResult.observe(this) {
             UserApiClient.instance.logout { showToast("오류 발생, 다시 로그인 해주세요. 사유: ${it.toString()}") }
@@ -48,11 +47,11 @@ class LoginActivity : AppCompatActivity() {
             if (error != null) {
                 Timber.e("로그인 실패 $error")
             } else if (token != null) {
-                Timber.i("로그인 성공 ${token.accessToken}")
-                // 서버에 토큰 달라고 요청
-                viewModel.getToken(RequestTokenDto(token.accessToken, KAKAO, "123"))
+                viewModel.setSocialToken(token.accessToken)
+                viewModel.getToken()
             }
         }
+
         binding.layoutLoginKakao.setOnClickListener {
             if (UserApiClient.instance.isKakaoTalkLoginAvailable(this)) {
                 // 카카오톡 로그인
@@ -73,8 +72,8 @@ class LoginActivity : AppCompatActivity() {
                     }
                     // 로그인 성공 부분
                     else if (token != null) {
-                        Timber.e("로그인 성공 ${token.accessToken}")
-                        viewModel.getToken(RequestTokenDto(token.accessToken, KAKAO, "123"))
+                        viewModel.setSocialToken(token.accessToken)
+                        viewModel.getToken()
                     }
                 }
             } else {
@@ -88,7 +87,6 @@ class LoginActivity : AppCompatActivity() {
     }
 
     companion object {
-        const val KAKAO: String = "kakao"
+        const val KAKAO: String = "KAKAO"
     }
-
 }

--- a/app/src/main/java/kr/co/nottodo/presentation/login/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/login/viewmodel/LoginViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.launch
 import kr.co.nottodo.data.remote.api.ServicePool
 import kr.co.nottodo.data.remote.model.RequestTokenDto
 import kr.co.nottodo.data.remote.model.ResponseTokenDto
+import kr.co.nottodo.presentation.login.view.LoginActivity.Companion.KAKAO
 
 class LoginViewModel : ViewModel() {
     private val tokenService by lazy { ServicePool.tokenService }
@@ -20,10 +21,21 @@ class LoginViewModel : ViewModel() {
     val getErrorResult: LiveData<String>
         get() = _getErrorResult
 
-    fun getToken(request: RequestTokenDto) {
+    private var socialToken: String? = null
+    fun setSocialToken(newSocialToken: String) {
+        socialToken = newSocialToken
+    }
+
+    fun getToken() {
         viewModelScope.launch {
             kotlin.runCatching {
-                tokenService.getToken(request)
+                tokenService.getToken(
+                    KAKAO, RequestTokenDto(
+                        socialToken ?: throw NullPointerException(
+                            "social token is null"
+                        ), "123"
+                    )
+                )
             }.fold(onSuccess = { _getTokenResult.value = it },
                 onFailure = { _getErrorResult.value = it.message })
         }


### PR DESCRIPTION
## 👻 작업한 내용
카카오 소셜로그인 API 부분을 수정하고,
해당 API를 통해 저장한 토큰을 사용해서 서버통신을 진행하도록, 즉 local.properties를 사용하지 않도록 로직을 수정했습니다.

## 🎤 PR Point

## 📸 스크린샷

## 📮 관련 이슈

- Resolved: #58 
