### PR TITLE
Fix/91 login 미친 마그마이슈 해결

### DIFF
--- a/app/src/main/java/kr/co/nottodo/Application.kt
+++ b/app/src/main/java/kr/co/nottodo/Application.kt
@@ -53,9 +53,6 @@ class Application : Application(), OnTokenExpiredListener {
     )
 
     private fun clearForLogout() {
-        SharedPreferences.apply {
-            clearForLogout()
-            setBoolean(LoginActivity.DID_USER_WATCHED_ONBOARD, true)
-        }
+        SharedPreferences.clearForLogout()
     }
 }

--- a/app/src/main/java/kr/co/nottodo/data/remote/api/TokenInterceptor.kt
+++ b/app/src/main/java/kr/co/nottodo/data/remote/api/TokenInterceptor.kt
@@ -11,16 +11,15 @@ class TokenInterceptor(private val onTokenExpiredListener: OnTokenExpiredListene
         val userToken = SharedPreferences.getString(USER_TOKEN)
 
         val originalRequest = chain.request()
-        val newRequest = originalRequest.newBuilder()
-        if (userToken != null) {
-            newRequest.header(
-                "Authorization", userToken
-            )
+        if (userToken.isNullOrBlank()) {
+            return chain.proceed(originalRequest)
         }
-        val response = chain.proceed(newRequest.build())
-        if (response.code == 401)
-            onTokenExpiredListener.onTokenExpired()
+        val tokenAddedRequest = originalRequest.newBuilder().header(
+            "Authorization", SharedPreferences.getString(USER_TOKEN) ?: ""
+        ).build()
 
-        return response
+        val response = chain.proceed(tokenAddedRequest)
+        if (response.code == 401) onTokenExpiredListener.onTokenExpired()
+        return chain.proceed(tokenAddedRequest)
     }
 }

--- a/app/src/main/java/kr/co/nottodo/presentation/login/view/LoginActivity.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/login/view/LoginActivity.kt
@@ -32,13 +32,6 @@ class LoginActivity : AppCompatActivity() {
         observeGetTokenResult()
     }
 
-    private fun setFCMToken() {
-        FirebaseMessaging.getInstance().token.addOnSuccessListener { token ->
-            viewModel.setFCMToken(token)
-            Timber.tag("fcm").e(token)
-        }
-    }
-
     private fun showOnboardForFirstUser() {
         if (!SharedPreferences.getBoolean(DID_USER_WATCHED_ONBOARD)) startActivity(
             Intent(
@@ -61,18 +54,18 @@ class LoginActivity : AppCompatActivity() {
             if (!isFinishing) finish()
         }
         viewModel.getErrorResult.observe(this) {
-            UserApiClient.instance.logout { showToast("오류 발생, 다시 로그인 해주세요. 사유: ${it.toString()}") }
+            UserApiClient.instance.logout { showToast("오류 발생, 다시 로그인 해주세요.") }
         }
     }
 
     private fun setKakaoLogin() {
-        val kakaoLoginCallback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
+        val kakaoLoginCallback: (OAuthToken?, Throwable?) -> Unit = { socialToken, error ->
             if (error != null) {
                 Timber.e("로그인 실패 $error")
-            } else if (token != null) {
-                setFCMToken()
-                viewModel.setSocialToken(token.accessToken)
-                viewModel.getToken()
+            } else if (socialToken != null) {
+                FirebaseMessaging.getInstance().token.addOnSuccessListener { fcmToken ->
+                    viewModel.login(socialToken = socialToken.accessToken, fcmToken = fcmToken)
+                }
             }
         }
 
@@ -100,9 +93,7 @@ class LoginActivity : AppCompatActivity() {
                     }
                     // 로그인 성공 부분
                     else if (token != null) {
-                        setFCMToken()
-                        viewModel.setSocialToken(token.accessToken)
-                        viewModel.getToken()
+                        kakaoLoginCallback.invoke(token, error)
                     }
                 }
             } else {
@@ -118,7 +109,6 @@ class LoginActivity : AppCompatActivity() {
     companion object {
         const val KAKAO: String = "KAKAO"
         const val USER_TOKEN = "USER_TOKEN"
-        const val FCM_TOKEN = "FCM_TOKEN"
         const val DID_USER_WATCHED_ONBOARD = "DID_USER_WATCHED_ONBOARD"
     }
 }

--- a/app/src/main/java/kr/co/nottodo/presentation/login/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/login/viewmodel/LoginViewModel.kt
@@ -32,16 +32,12 @@ class LoginViewModel : ViewModel() {
         FCMToken = newFCMToken
     }
 
-    fun getToken() {
+    fun login(socialToken: String, fcmToken: String) {
         viewModelScope.launch {
             kotlin.runCatching {
                 tokenService.getToken(
                     KAKAO, RequestTokenDto(
-                        socialToken ?: throw NullPointerException(
-                            "social token is null"
-                        ), FCMToken ?: throw NullPointerException(
-                            "fcm token is null"
-                        )
+                        socialToken = socialToken, fcmToken = fcmToken
                     )
                 )
             }.fold(onSuccess = { _getTokenResult.value = it },


### PR DESCRIPTION
## 👻 작업한 내용
### 미친 카카오로그인 안 되는 이슈 해결
제가 SharedPreferences에서 키가 USER_TOKEN 을 가져왔을 때 Null이 아니면 헤더에 넣었는데,
SharedPreferences.clear() 메서드는 이 내용을 아예 지우는 게 아니라, 공백으로 만들어줍니다.
따라서 헤더에 공백값이면 아예 가면 안되는데 갔던거죠....
## 🎤 PR Point

## 📸 스크린샷

## 📮 관련 이슈

- Resolved: #91 
