### PR TITLE
[feature] 다른 날도 할래요에서 이미 낫투두 설정되어 있는 날 체크

### DIFF
--- a/app/src/main/java/kr/co/nottodo/view/calendar/monthly/monthlycalendarpicker/MonthlyCalendarMultiplePicker.kt
+++ b/app/src/main/java/kr/co/nottodo/view/calendar/monthly/monthlycalendarpicker/MonthlyCalendarMultiplePicker.kt
@@ -392,6 +392,16 @@ class MonthlyCalendarMultiplePicker @JvmOverloads constructor(
         monthlyCalendarMultiplePickerDayAdapter.submitList(emptyList())
     }
 
+    /**
+     * 이미 낫투두 날짜가 정해져 있는 데이터 넣어주는 함수
+     */
+    fun setScheduledNotTodoDateList(list: List<Date>) {
+        val current7DayList = getAvailableDateList()
+        monthlyCalendarMultiplePickerDayAdapter.submitScheduledNotTodoList(
+            list.filter { current7DayList.any { it.isTheSameDay(it) } }
+        )
+    }
+
     override fun onDayClick(view: View, date: Date) {
         monthlyCalendarPickerClickListener?.onDayClick(view, date)
         monthlyCalendarMultiplePickerDayAdapter.setSelectedDay(date)

--- a/app/src/main/java/kr/co/nottodo/view/calendar/monthly/monthlycalendarpicker/adapter/MonthlyCalendarMultiplePickerDayAdapter.kt
+++ b/app/src/main/java/kr/co/nottodo/view/calendar/monthly/monthlycalendarpicker/adapter/MonthlyCalendarMultiplePickerDayAdapter.kt
@@ -25,6 +25,9 @@ class MonthlyCalendarMultiplePickerDayAdapter(
 
     private val selectedDateList = mutableListOf<Date>()
 
+    // 이미 낫투두가 설정되어 있는 날 리스트
+    private val notTodoScheduledDateList = mutableListOf<Date>()
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val layoutInflater = LayoutInflater.from(parent.context)
         return when (viewType) {
@@ -62,10 +65,14 @@ class MonthlyCalendarMultiplePickerDayAdapter(
         when (holder) {
             is MonthlyCalendarPickerDayViewHolder -> {
                 if (calendarPickerItems[position] is MonthlyCalendarDay.DayMonthly) {
-                    if (selectedDateList.any { it.isTheSameDay((calendarPickerItems[position] as MonthlyCalendarDay.DayMonthly).date) }) {
-                        holder.onBindSelectedState(calendarPickerItems[position])
+                    if (notTodoScheduledDateList.any { it.isTheSameDay((calendarPickerItems[position] as MonthlyCalendarDay.DayMonthly).date) }) {
+                        holder.onBindScheduledState(calendarPickerItems[position])
                     } else {
-                        holder.onBind(calendarPickerItems[position])
+                        if (selectedDateList.any { it.isTheSameDay((calendarPickerItems[position] as MonthlyCalendarDay.DayMonthly).date) }) {
+                            holder.onBindSelectedState(calendarPickerItems[position])
+                        } else {
+                            holder.onBind(calendarPickerItems[position])
+                        }
                     }
                 } else {
                     holder.onBind(calendarPickerItems[position])
@@ -90,6 +97,16 @@ class MonthlyCalendarMultiplePickerDayAdapter(
     fun submitList(list: List<MonthlyCalendarDay>) {
         calendarPickerItems.clear()
         calendarPickerItems.addAll(list)
+        notifyDataSetChanged()
+    }
+
+    /**
+     * 이미 낫투두 날짜가 정해져 있는 경우의 데이터를 확인하기 위한 함수
+     */
+    @SuppressLint("NotifyDataSetChanged")
+    fun submitScheduledNotTodoList(list: List<Date>) {
+        notTodoScheduledDateList.clear()
+        notTodoScheduledDateList.addAll(list)
         notifyDataSetChanged()
     }
 

--- a/app/src/main/java/kr/co/nottodo/view/calendar/monthly/monthlycalendarpicker/viewholder/MonthlyCalendarPickerDayViewHolder.kt
+++ b/app/src/main/java/kr/co/nottodo/view/calendar/monthly/monthlycalendarpicker/viewholder/MonthlyCalendarPickerDayViewHolder.kt
@@ -9,6 +9,7 @@ import kr.co.nottodo.R
 import kr.co.nottodo.databinding.ViewMonthlyCalendarPickerDayBinding
 import kr.co.nottodo.view.calendar.monthly.model.DateType
 import kr.co.nottodo.view.calendar.monthly.model.MonthlyCalendarDay
+import kr.co.nottodo.view.calendar.monthly.monthlycalendar.MonthlyCalendar
 import kr.co.nottodo.view.calendar.monthly.monthlycalendarpicker.listener.MonthlyCalendarPickerClickListener
 
 class MonthlyCalendarPickerDayViewHolder(
@@ -56,7 +57,11 @@ class MonthlyCalendarPickerDayViewHolder(
                 executePendingBindings()
 
                 // ui
-                ivMonthlyCalendarPickerDayIndicator.visibility = View.VISIBLE
+                with(ivMonthlyCalendarPickerDayIndicator) {
+                    visibility = View.VISIBLE
+                    setImageDrawable(ContextCompat.getDrawable(context,R.drawable.circle_solid_white_width_38dp))
+                }
+
                 tvDay.setTextColor(
                     ContextCompat.getColor(
                         binding.root.context,
@@ -66,6 +71,42 @@ class MonthlyCalendarPickerDayViewHolder(
                             DateType.DISABLED -> {
                                 throw IllegalStateException("check day state")
                             }
+                        }
+                    )
+                )
+            }
+        }
+    }
+
+    fun onBindScheduledState(data: MonthlyCalendarDay) {
+        // 클릭 안되게 해야함
+        if (data is MonthlyCalendarDay.DayMonthly) {
+            dayData = data
+            with(binding) {
+                day = data
+                executePendingBindings()
+
+                // ui
+
+                // 클릭 방지 블록
+                if (root.hasOnClickListeners()) {
+                    root.setOnClickListener(null)
+                }
+
+                with(ivMonthlyCalendarPickerDayIndicator) {
+                    visibility = View.VISIBLE
+                    setImageDrawable(
+                        ContextCompat.getDrawable(context,R.drawable.circle_gray_5d5d6b)
+                    )
+                }
+
+                tvDay.setTextColor(
+                    ContextCompat.getColor(
+                        binding.root.context,
+                        when (data.state) {
+                            DateType.WEEKDAY,
+                            DateType.WEEKEND -> R.color.white
+                            DateType.DISABLED -> R.color.gray_7_8e8e93
                         }
                     )
                 )

--- a/app/src/main/res/drawable/circle_gray_5d5d6b.xml
+++ b/app/src/main/res/drawable/circle_gray_5d5d6b.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="38dp"
+    android:height="38dp"
+    android:viewportWidth="38"
+    android:viewportHeight="38">
+  <path
+      android:pathData="M19,19m-19,0a19,19 0,1 1,38 0a19,19 0,1 1,-38 0"
+      android:fillColor="#5D5D6B"/>
+</vector>


### PR DESCRIPTION
## 👻 작업한 내용
- 다른 날도 할래요 이미 낫투두 설정되어 있는 경우 회색 동그라미로 표시
## 🎤 PR Point
- 서버 API를 통해서 받아온 이미 설정된 낫투두 날짜를 Calendar 객체의 setScheduledNotTodoDateList() 함수로 넣어준다.
- 클릭이 안되는지와 여러 기능 체크 요망
- 연결 로직이라서 체크해보고 확인하는 걸 추천합니다

## 📸 스크린샷

## 📮 관련 이슈

- Resolved: #
