### PR TITLE
[feat]#143 trackingSessionEvents 꺼서 Start Session, End Session 보내지 않게 하기

### DIFF
--- a/app/src/main/java/kr/co/nottodo/util/Amplitude.kt
+++ b/app/src/main/java/kr/co/nottodo/util/Amplitude.kt
@@ -11,7 +11,9 @@ object Amplitude {
     fun initAmplitude(applicationContext: Context) {
         amplitude = Amplitude(
             Configuration(
-                apiKey = BuildConfig.AMPLITUDE_API_KEY, context = applicationContext
+                apiKey = BuildConfig.AMPLITUDE_API_KEY,
+                context = applicationContext,
+                trackingSessionEvents = false
             )
         )
     }

--- a/app/src/main/java/kr/co/nottodo/util/NotTodoAmplitude.kt
+++ b/app/src/main/java/kr/co/nottodo/util/NotTodoAmplitude.kt
@@ -5,7 +5,7 @@ import com.amplitude.android.Amplitude
 import com.amplitude.android.Configuration
 import kr.co.nottodo.BuildConfig
 
-object Amplitude {
+object NotTodoAmplitude {
     private lateinit var amplitude: Amplitude
 
     fun initAmplitude(applicationContext: Context) {


### PR DESCRIPTION
## 👻 작업한 내용
### trackingSessionEvents 꺼서 Start Session, End Session 보내지 않게 하기
## 🎤 PR Point
처음 쓰는 라이브러리다 보니 빼놓은 기능이 넘 많네요.. 잦은 PR 죄송합니다.
앱 사용 시작과 끝을 보내는 trackingSessionEvents가 기본값이 false인줄 알았으나 true여서 수정하였습니다.
## 📸 스크린샷

## 📮 관련 이슈

- Resolved: #143 
