### PR TITLE
Feat/205 login acitvity to fragment

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,6 +44,10 @@
             android:windowSoftInputMode="stateAlwaysHidden" />
         <activity
             android:name=".presentation.login.view.LoginActivity"
+            android:exported="false"
+            android:screenOrientation="portrait" />
+        <activity
+            android:name=".MainActivity"
             android:exported="true"
             android:screenOrientation="portrait">
             <intent-filter>
@@ -52,10 +56,6 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity
-            android:name=".MainActivity"
-            android:exported="false"
-            android:screenOrientation="portrait" />
         <activity
             android:name=".presentation.modification.view.ModificationActivity"
             android:exported="false"

--- a/app/src/main/java/kr/co/nottodo/Application.kt
+++ b/app/src/main/java/kr/co/nottodo/Application.kt
@@ -8,7 +8,6 @@ import com.kakao.sdk.common.KakaoSdk
 import kr.co.nottodo.data.local.SharedPreferences
 import kr.co.nottodo.data.remote.api.ApiFactory
 import kr.co.nottodo.listeners.OnTokenExpiredListener
-import kr.co.nottodo.presentation.login.view.LoginActivity
 import kr.co.nottodo.util.NotTodoAmplitude.initAmplitude
 import kr.co.nottodo.util.NotTodoDebugTree
 import timber.log.Timber
@@ -56,9 +55,9 @@ class Application : Application(), OnTokenExpiredListener {
     }
 
     private fun navigateToLogin() = startActivity(
-        Intent(this, LoginActivity::class.java).setFlags(
-            Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK,
-        ),
+        Intent(this, MainActivity::class.java).setFlags(
+            Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        )
     )
 
     private fun clearForLogout() {

--- a/app/src/main/java/kr/co/nottodo/MainActivity.kt
+++ b/app/src/main/java/kr/co/nottodo/MainActivity.kt
@@ -138,6 +138,11 @@ class MainActivity : AppCompatActivity(), OnFragmentChangedListener {
     private fun overrideBackPressed() {
         val callback = object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
+                if (navController.currentDestination?.id == R.id.loginFragment) {
+                    if (!isFinishing) finish()
+                    return
+                }
+
                 if (!binding.bnvMain.isVisible) {
                     navController.popBackStack()
                     return

--- a/app/src/main/java/kr/co/nottodo/MainActivity.kt
+++ b/app/src/main/java/kr/co/nottodo/MainActivity.kt
@@ -20,6 +20,7 @@ import com.google.android.material.shape.CornerFamily
 import com.google.android.material.shape.MaterialShapeDrawable
 import kr.co.nottodo.data.local.SharedPreferences
 import kr.co.nottodo.databinding.ActivityMainBinding
+import kr.co.nottodo.listeners.OnWithdrawalDialogDismissListener
 import kr.co.nottodo.listeners.OnFragmentChangedListener
 import kr.co.nottodo.presentation.achieve.AchieveFragment
 import kr.co.nottodo.presentation.home.view.HomeFragment
@@ -27,7 +28,7 @@ import kr.co.nottodo.presentation.login.view.LoginActivity.Companion.DID_USER_CH
 import kr.co.nottodo.presentation.mypage.view.MyPageFragment
 import kr.co.nottodo.util.showToast
 
-class MainActivity : AppCompatActivity(), OnFragmentChangedListener {
+class MainActivity : AppCompatActivity(), OnFragmentChangedListener, OnWithdrawalDialogDismissListener {
     private lateinit var binding: ActivityMainBinding
     private lateinit var requestPermissionLauncher: ActivityResultLauncher<String>
     private val navController by lazy {
@@ -163,6 +164,20 @@ class MainActivity : AppCompatActivity(), OnFragmentChangedListener {
         }
         onBackPressedDispatcher.addCallback(this, callback)
     }
+
+    override fun onWithdrawalDialogDismiss() {
+        logout()
+    }
+
+    private fun logout() {
+        SharedPreferences.clearForLogout()
+        navigateToLogin()
+    }
+
+    private fun navigateToLogin() {
+        navController.navigate(R.id.loginFragment)
+    }
+
 
     companion object {
         const val BLANK = ""

--- a/app/src/main/java/kr/co/nottodo/listeners/OnDialogDismissListener.kt
+++ b/app/src/main/java/kr/co/nottodo/listeners/OnDialogDismissListener.kt
@@ -1,5 +1,0 @@
-package kr.co.nottodo.listeners
-
-interface OnDialogDismissListener {
-    fun onDialogDismiss()
-}

--- a/app/src/main/java/kr/co/nottodo/listeners/OnWithdrawalDialogDismissListener.kt
+++ b/app/src/main/java/kr/co/nottodo/listeners/OnWithdrawalDialogDismissListener.kt
@@ -1,0 +1,5 @@
+package kr.co.nottodo.listeners
+
+interface OnWithdrawalDialogDismissListener {
+    fun onWithdrawalDialogDismiss()
+}

--- a/app/src/main/java/kr/co/nottodo/presentation/login/view/LoginActivity.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/login/view/LoginActivity.kt
@@ -16,7 +16,7 @@ import kr.co.nottodo.data.local.SharedPreferences
 import kr.co.nottodo.databinding.ActivityLoginBinding
 import kr.co.nottodo.presentation.login.viewmodel.LoginViewModel
 import kr.co.nottodo.presentation.onboard.view.OnboardActivity
-import kr.co.nottodo.util.NotTodoAmplitude.setUserId
+import kr.co.nottodo.util.NotTodoAmplitude.setAmplitudeUserId
 import kr.co.nottodo.util.NotTodoAmplitude.trackEvent
 import kr.co.nottodo.util.NotTodoAmplitude.trackEventWithProperty
 import kr.co.nottodo.util.showToast
@@ -147,7 +147,7 @@ class LoginActivity : AppCompatActivity() {
                     R.string.kakao
                 )
             )
-            setUserId(response.data.userId)
+            setAmplitudeUserId(response.data.userId)
             startActivity(Intent(this, MainActivity::class.java))
             setUserInfo(response.data.accessToken)
             if (!isFinishing) finish()

--- a/app/src/main/java/kr/co/nottodo/presentation/login/view/LoginFragment.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/login/view/LoginFragment.kt
@@ -1,0 +1,181 @@
+package kr.co.nottodo.presentation.login.view
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import com.google.firebase.messaging.FirebaseMessaging
+import com.kakao.sdk.auth.model.OAuthToken
+import com.kakao.sdk.common.model.ClientError
+import com.kakao.sdk.common.model.ClientErrorCause
+import com.kakao.sdk.user.UserApiClient
+import kr.co.nottodo.MainActivity
+import kr.co.nottodo.R
+import kr.co.nottodo.data.local.SharedPreferences
+import kr.co.nottodo.databinding.ActivityLoginBinding
+import kr.co.nottodo.presentation.base.fragment.ViewBindingFragment
+import kr.co.nottodo.presentation.login.viewmodel.LoginViewModel
+import kr.co.nottodo.presentation.onboard.view.OnboardActivity
+import kr.co.nottodo.util.NotTodoAmplitude.setUserId
+import kr.co.nottodo.util.NotTodoAmplitude.trackEvent
+import kr.co.nottodo.util.NotTodoAmplitude.trackEventWithProperty
+import kr.co.nottodo.util.showToast
+import timber.log.Timber
+
+class LoginFragment : ViewBindingFragment<ActivityLoginBinding>() {
+    private val viewModel: LoginViewModel by viewModels()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        showOnboardForFirstUser()
+        setAutoLogin()
+        observeGetTokenResult()
+        setClickEvents()
+    }
+
+    private fun setClickEvents() {
+        setGoogleLoginBtnClickEvent()
+        setKakaoLoginBtnClickEvent()
+        setTermsOfUseTvClickEvent()
+        setPrivacyPolicyTvClickEvent()
+    }
+
+    private fun setTermsOfUseTvClickEvent() {
+        binding.tvLoginTermsOfUse.setOnClickListener {
+            val intent = Intent(
+                Intent.ACTION_VIEW, Uri.parse(getString(R.string.url_terms_of_use))
+            )
+            startActivity(intent)
+        }
+    }
+
+    private fun setPrivacyPolicyTvClickEvent() {
+        binding.tvLoginPrivacyPolicy.setOnClickListener {
+            val intent = Intent(
+                Intent.ACTION_VIEW, Uri.parse(getString(R.string.url_privacy_policy))
+            )
+            startActivity(intent)
+        }
+    }
+
+
+    private fun setGoogleLoginBtnClickEvent() {
+        binding.layoutLoginGoogle.setOnClickListener {
+            requireContext().showToast(getString(R.string.google_sign_in_later))
+        }
+    }
+
+    private fun setKakaoLoginBtnClickEvent() {
+        val kakaoLoginCallback: (OAuthToken?, Throwable?) -> Unit = { socialToken, error ->
+            if (error != null) {
+                Timber.e(getString(R.string.failure_kakao_login, error))
+            } else if (socialToken != null) {
+                FirebaseMessaging.getInstance().token.addOnSuccessListener { fcmToken ->
+                    viewModel.login(socialToken = socialToken.accessToken, fcmToken = fcmToken)
+                }
+            }
+        }
+
+        binding.layoutLoginKakao.setOnClickListener {
+            trackEventWithProperty(
+                getString(R.string.click_signin), getString(R.string.provider), getString(
+                    R.string.kakao
+                )
+            )
+            if (UserApiClient.instance.isKakaoTalkLoginAvailable(requireContext())) {
+                // 카카오톡 로그인
+                UserApiClient.instance.loginWithKakaoTalk(requireContext()) { token, error ->
+                    // 로그인 실패 부분
+                    if (error != null) {
+                        Timber.e(getString(R.string.failure_kakao_login, error))
+                        // 사용자 취소
+                        if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
+                            return@loginWithKakaoTalk
+                        }
+                        // 다른 오류 - 카톡으로 안 될 경우
+                        else {
+                            UserApiClient.instance.loginWithKakaoAccount(
+                                requireContext(), callback = kakaoLoginCallback
+                            ) // 카카오 이메일 로그인
+                        }
+                    }
+                    // 로그인 성공 부분
+                    else if (token != null) {
+                        kakaoLoginCallback.invoke(token, error)
+                    }
+                }
+            } else {
+                Timber.d(getString(R.string.kakao_talk_not_installed))
+                // 카카오 이메일 로그인
+                UserApiClient.instance.loginWithKakaoAccount(
+                    requireContext(), callback = kakaoLoginCallback
+                )
+            }
+        }
+    }
+
+    private fun showOnboardForFirstUser() {
+        if (!SharedPreferences.getBoolean(DID_USER_WATCHED_ONBOARD)) {
+            startActivity(
+                Intent(
+                    requireContext(), OnboardActivity::class.java
+                )
+            )
+            if (!requireActivity().isFinishing) requireActivity().finish()
+        }
+    }
+
+    private fun setAutoLogin() {
+        if (!SharedPreferences.getString(USER_TOKEN).isNullOrBlank()) {
+            startActivity(Intent(requireContext(), MainActivity::class.java))
+            if (!requireActivity().isFinishing) requireActivity().finish()
+        } else {
+            trackEvent(getString(R.string.view_signin))
+        }
+    }
+
+    private fun observeGetTokenResult() {
+        viewModel.getTokenResult.observe(viewLifecycleOwner) { response ->
+            trackEventWithProperty(
+                getString(R.string.complete_signin), getString(R.string.provider), getString(
+                    R.string.kakao
+                )
+            )
+            setUserId(response.data.userId)
+            startActivity(Intent(requireContext(), MainActivity::class.java))
+            setUserInfo(response.data.accessToken)
+            if (!requireActivity().isFinishing) requireActivity().finish()
+        }
+        viewModel.getErrorResult.observe(viewLifecycleOwner) {
+            UserApiClient.instance.logout { requireContext().showToast(getString(R.string.error_login_again_please)) }
+        }
+    }
+
+    private fun setUserInfo(token: String) {
+        SharedPreferences.apply {
+            setString(USER_TOKEN, token)
+            UserApiClient.instance.me { user, error ->
+                if (error == null && user != null) {
+                    setString(USER_EMAIL, user.kakaoAccount?.email)
+                    setString(USER_NAME, user.kakaoAccount?.profile?.nickname)
+                }
+            }
+        }
+    }
+
+    override fun setBinding(inflater: LayoutInflater, container: ViewGroup?): ActivityLoginBinding =
+        ActivityLoginBinding.inflate(inflater, container, false)
+
+    companion object {
+        const val KAKAO: String = "KAKAO"
+        const val USER_TOKEN = "USER_TOKEN"
+        const val DID_USER_WATCHED_ONBOARD = "DID_USER_WATCHED_ONBOARD"
+        const val USER_NAME = "USER_NAME"
+        const val USER_EMAIL = "USER_EMAIL"
+        const val DID_USER_CHOOSE_TO_BE_NOTIFIED = "DID_USER_CHOOSE_TO_BE_NOTIFIED"
+    }
+}

--- a/app/src/main/java/kr/co/nottodo/presentation/login/view/LoginFragment.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/login/view/LoginFragment.kt
@@ -19,7 +19,7 @@ import kr.co.nottodo.databinding.ActivityLoginBinding
 import kr.co.nottodo.presentation.base.fragment.ViewBindingFragment
 import kr.co.nottodo.presentation.login.viewmodel.LoginViewModel
 import kr.co.nottodo.presentation.onboard.view.OnboardActivity
-import kr.co.nottodo.util.NotTodoAmplitude.setUserId
+import kr.co.nottodo.util.NotTodoAmplitude.setAmplitudeUserId
 import kr.co.nottodo.util.NotTodoAmplitude.trackEvent
 import kr.co.nottodo.util.NotTodoAmplitude.trackEventWithProperty
 import kr.co.nottodo.util.showToast
@@ -33,8 +33,31 @@ class LoginFragment : ViewBindingFragment<ActivityLoginBinding>() {
 
         showOnboardForFirstUser()
         setAutoLogin()
-        observeGetTokenResult()
         setClickEvents()
+        observeGetTokenResult()
+    }
+
+    private fun showOnboardForFirstUser() {
+        if (!SharedPreferences.getBoolean(DID_USER_WATCHED_ONBOARD)) {
+            startActivity(
+                Intent(
+                    requireContext(), OnboardActivity::class.java
+                )
+            )
+            if (!requireActivity().isFinishing) requireActivity().finish()
+        }
+    }
+
+    private fun setAutoLogin() {
+        if (!SharedPreferences.getString(USER_TOKEN).isNullOrBlank()) {
+            navigateToHome()
+        } else {
+            trackEvent(getString(R.string.view_signin))
+        }
+    }
+
+    private fun navigateToHome() {
+        findNavController().navigate(R.id.action_loginFragment_to_homeFragment)
     }
 
     private fun setClickEvents() {
@@ -43,25 +66,6 @@ class LoginFragment : ViewBindingFragment<ActivityLoginBinding>() {
         setTermsOfUseTvClickEvent()
         setPrivacyPolicyTvClickEvent()
     }
-
-    private fun setTermsOfUseTvClickEvent() {
-        binding.tvLoginTermsOfUse.setOnClickListener {
-            val intent = Intent(
-                Intent.ACTION_VIEW, Uri.parse(getString(R.string.url_terms_of_use))
-            )
-            startActivity(intent)
-        }
-    }
-
-    private fun setPrivacyPolicyTvClickEvent() {
-        binding.tvLoginPrivacyPolicy.setOnClickListener {
-            val intent = Intent(
-                Intent.ACTION_VIEW, Uri.parse(getString(R.string.url_privacy_policy))
-            )
-            startActivity(intent)
-        }
-    }
-
 
     private fun setGoogleLoginBtnClickEvent() {
         binding.layoutLoginGoogle.setOnClickListener {
@@ -118,27 +122,22 @@ class LoginFragment : ViewBindingFragment<ActivityLoginBinding>() {
         }
     }
 
-    private fun showOnboardForFirstUser() {
-        if (!SharedPreferences.getBoolean(DID_USER_WATCHED_ONBOARD)) {
-            startActivity(
-                Intent(
-                    requireContext(), OnboardActivity::class.java
-                )
+    private fun setTermsOfUseTvClickEvent() {
+        binding.tvLoginTermsOfUse.setOnClickListener {
+            val intent = Intent(
+                Intent.ACTION_VIEW, Uri.parse(getString(R.string.url_terms_of_use))
             )
-            if (!requireActivity().isFinishing) requireActivity().finish()
+            startActivity(intent)
         }
     }
 
-    private fun setAutoLogin() {
-        if (!SharedPreferences.getString(USER_TOKEN).isNullOrBlank()) {
-            navigateToHome()
-        } else {
-            trackEvent(getString(R.string.view_signin))
+    private fun setPrivacyPolicyTvClickEvent() {
+        binding.tvLoginPrivacyPolicy.setOnClickListener {
+            val intent = Intent(
+                Intent.ACTION_VIEW, Uri.parse(getString(R.string.url_privacy_policy))
+            )
+            startActivity(intent)
         }
-    }
-
-    private fun navigateToHome() {
-        findNavController().navigate(R.id.action_loginFragment_to_homeFragment)
     }
 
     private fun observeGetTokenResult() {
@@ -148,7 +147,7 @@ class LoginFragment : ViewBindingFragment<ActivityLoginBinding>() {
                     R.string.kakao
                 )
             )
-            setUserId(response.data.userId)
+            setAmplitudeUserId(response.data.userId)
             setUserInfo(response.data.accessToken)
             navigateToHome()
         }

--- a/app/src/main/java/kr/co/nottodo/presentation/login/view/LoginFragment.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/login/view/LoginFragment.kt
@@ -7,12 +7,12 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.google.firebase.messaging.FirebaseMessaging
 import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
 import com.kakao.sdk.user.UserApiClient
-import kr.co.nottodo.MainActivity
 import kr.co.nottodo.R
 import kr.co.nottodo.data.local.SharedPreferences
 import kr.co.nottodo.databinding.ActivityLoginBinding
@@ -131,11 +131,14 @@ class LoginFragment : ViewBindingFragment<ActivityLoginBinding>() {
 
     private fun setAutoLogin() {
         if (!SharedPreferences.getString(USER_TOKEN).isNullOrBlank()) {
-            startActivity(Intent(requireContext(), MainActivity::class.java))
-            if (!requireActivity().isFinishing) requireActivity().finish()
+            navigateToHome()
         } else {
             trackEvent(getString(R.string.view_signin))
         }
+    }
+
+    private fun navigateToHome() {
+        findNavController().navigate(R.id.action_loginFragment_to_homeFragment)
     }
 
     private fun observeGetTokenResult() {
@@ -146,9 +149,8 @@ class LoginFragment : ViewBindingFragment<ActivityLoginBinding>() {
                 )
             )
             setUserId(response.data.userId)
-            startActivity(Intent(requireContext(), MainActivity::class.java))
             setUserInfo(response.data.accessToken)
-            if (!requireActivity().isFinishing) requireActivity().finish()
+            navigateToHome()
         }
         viewModel.getErrorResult.observe(viewLifecycleOwner) {
             UserApiClient.instance.logout { requireContext().showToast(getString(R.string.error_login_again_please)) }

--- a/app/src/main/java/kr/co/nottodo/presentation/login/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/login/viewmodel/LoginViewModel.kt
@@ -5,13 +5,12 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
-import kr.co.nottodo.data.remote.api.ServicePool
+import kr.co.nottodo.data.remote.api.ServicePool.tokenService
 import kr.co.nottodo.data.remote.model.login.RequestTokenDto
 import kr.co.nottodo.data.remote.model.login.ResponseTokenDto
 import kr.co.nottodo.presentation.login.view.LoginActivity.Companion.KAKAO
 
 class LoginViewModel : ViewModel() {
-    private val tokenService by lazy { ServicePool.tokenService }
 
     private val _getTokenResult: MutableLiveData<ResponseTokenDto> = MutableLiveData()
     val getTokenResult: LiveData<ResponseTokenDto>

--- a/app/src/main/java/kr/co/nottodo/presentation/mypage/view/MyPageInformationActivity.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/mypage/view/MyPageInformationActivity.kt
@@ -13,7 +13,7 @@ import androidx.core.content.ContextCompat
 import kr.co.nottodo.R
 import kr.co.nottodo.data.local.SharedPreferences
 import kr.co.nottodo.databinding.ActivityMyPageInformationBinding
-import kr.co.nottodo.listeners.OnDialogDismissListener
+import kr.co.nottodo.listeners.OnWithdrawalDialogDismissListener
 import kr.co.nottodo.presentation.login.view.LoginActivity
 import kr.co.nottodo.presentation.login.view.LoginActivity.Companion.DID_USER_CHOOSE_TO_BE_NOTIFIED
 import kr.co.nottodo.presentation.mypage.viewmodel.MyPageInformationViewModel
@@ -23,7 +23,7 @@ import kr.co.nottodo.util.showNotTodoSnackBar
 import kr.co.nottodo.util.showToast
 
 
-class MyPageInformationActivity : AppCompatActivity(), OnDialogDismissListener {
+class MyPageInformationActivity : AppCompatActivity(), OnWithdrawalDialogDismissListener {
     lateinit var binding: ActivityMyPageInformationBinding
     private val viewModel by viewModels<MyPageInformationViewModel>()
     private val withdrawalDialogFragment by lazy { WithdrawalDialogFragment() }
@@ -192,7 +192,7 @@ class MyPageInformationActivity : AppCompatActivity(), OnDialogDismissListener {
         if (!isFinishing) finish()
     }
 
-    override fun onDialogDismiss() {
+    override fun onWithdrawalDialogDismiss() {
         logout()
     }
 }

--- a/app/src/main/java/kr/co/nottodo/presentation/mypage/view/MyPageInformationFragment.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/mypage/view/MyPageInformationFragment.kt
@@ -14,24 +14,18 @@ import androidx.navigation.fragment.findNavController
 import kr.co.nottodo.R
 import kr.co.nottodo.data.local.SharedPreferences
 import kr.co.nottodo.databinding.FragmentMyPageInformationBinding
-import kr.co.nottodo.listeners.OnDialogDismissListener
 import kr.co.nottodo.presentation.base.fragment.DataBindingFragment
 import kr.co.nottodo.presentation.login.view.LoginActivity
 import kr.co.nottodo.presentation.login.view.LoginActivity.Companion.DID_USER_CHOOSE_TO_BE_NOTIFIED
-import kr.co.nottodo.presentation.mypage.viewmodel.MyPageInformationViewModel
+import kr.co.nottodo.presentation.mypage.viewmodel.MyPageInformationNewViewModel
 import kr.co.nottodo.util.NotTodoAmplitude.trackEvent
-import kr.co.nottodo.util.PublicString.NO_INTERNET_CONDITION_ERROR
-import kr.co.nottodo.util.showNotTodoSnackBar
-import kr.co.nottodo.util.showToast
 
 
 class MyPageInformationFragment :
-    DataBindingFragment<FragmentMyPageInformationBinding>(R.layout.fragment_my_page_information),
-    OnDialogDismissListener {
+    DataBindingFragment<FragmentMyPageInformationBinding>(R.layout.fragment_my_page_information) {
 
-    private val viewModel: MyPageInformationViewModel by viewModels()
+    private val viewModel: MyPageInformationNewViewModel by viewModels()
     private val withdrawalDialogFragment by lazy { WithdrawalDialogFragment.newInstance() }
-    private val withdrawalFeedbackDialogFragment by lazy { WithdrawalFeedbackDialogFragment.newInstance() }
     private val myPageLogoutDialogFragment by lazy { MyPageLogoutDialogFragment.newInstance() }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -40,7 +34,6 @@ class MyPageInformationFragment :
         trackEnterMyPageInformation()
         setViews()
         setClickEvents()
-        setObservers()
     }
 
     private fun trackEnterMyPageInformation() {
@@ -164,45 +157,6 @@ class MyPageInformationFragment :
         binding.ivMyPageInformationBackArrow.setOnClickListener {
             findNavController().popBackStack()
         }
-    }
-
-    private fun setObservers() {
-        setWithdrawalObserver()
-    }
-
-    private fun setWithdrawalObserver() {
-        setWithdrawalSuccessObserver()
-        setWithdrawalErrorObserver()
-    }
-
-    private fun setWithdrawalErrorObserver() {
-        viewModel.withdrawalErrorResponse.observe(viewLifecycleOwner) { errorMessage ->
-            if (errorMessage == NO_INTERNET_CONDITION_ERROR) requireContext().showNotTodoSnackBar(
-                binding.root, NO_INTERNET_CONDITION_ERROR
-            )
-            else requireContext().showToast(errorMessage)
-        }
-    }
-
-    private fun setWithdrawalSuccessObserver() {
-        viewModel.withdrawalSuccessResponse.observe(viewLifecycleOwner) {
-            withdrawalDialogFragment.dismiss()
-            withdrawalFeedbackDialogFragment.show(
-                requireActivity().supportFragmentManager, withdrawalFeedbackDialogFragment.tag
-            )
-            trackEvent(getString(R.string.complete_withdrawal))
-        }
-    }
-
-
-    override fun onDialogDismiss() {
-        logout()
-    }
-
-    private fun logout() {
-        SharedPreferences.clearForLogout()
-        startActivity(Intent(requireContext(), LoginActivity::class.java))
-        if (!requireActivity().isFinishing) requireActivity().finish()
     }
 
     override fun bindViewModelWithBinding() {

--- a/app/src/main/java/kr/co/nottodo/presentation/mypage/view/MyPageLogoutDialogFragment.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/mypage/view/MyPageLogoutDialogFragment.kt
@@ -1,13 +1,12 @@
 package kr.co.nottodo.presentation.mypage.view
 
 import android.app.Dialog
-import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
+import androidx.navigation.fragment.findNavController
 import kr.co.nottodo.R
 import kr.co.nottodo.data.local.SharedPreferences
-import kr.co.nottodo.presentation.login.view.LoginActivity
 import kr.co.nottodo.util.NotTodoAmplitude.trackEvent
 
 class MyPageLogoutDialogFragment : DialogFragment() {
@@ -31,12 +30,11 @@ class MyPageLogoutDialogFragment : DialogFragment() {
     private fun logout() {
         trackEvent(getString(R.string.complete_logout))
         SharedPreferences.clearForLogout()
-        startActivity(
-            Intent(
-                requireContext(), LoginActivity::class.java
-            ).setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
-        )
-        if (!requireActivity().isFinishing) requireActivity().finish()
+        navigateToLogin()
+    }
+
+    private fun navigateToLogin() {
+        findNavController().navigate(R.id.action_myPageInformationFragment_to_loginFragment)
     }
 
     companion object {

--- a/app/src/main/java/kr/co/nottodo/presentation/mypage/view/WithdrawalDialogFragment.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/mypage/view/WithdrawalDialogFragment.kt
@@ -5,16 +5,20 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
-import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import kr.co.nottodo.R
 import kr.co.nottodo.databinding.FragmentWithdrawalDialogBinding
-import kr.co.nottodo.presentation.mypage.viewmodel.MyPageInformationViewModel
+import kr.co.nottodo.presentation.mypage.viewmodel.WithdrawalDialogViewModel
 import kr.co.nottodo.util.NotTodoAmplitude.trackEvent
+import kr.co.nottodo.util.PublicString
+import kr.co.nottodo.util.showNotTodoSnackBar
+import kr.co.nottodo.util.showToast
 
 class WithdrawalDialogFragment : DialogFragment() {
     private var _binding: FragmentWithdrawalDialogBinding? = null
     private val binding get() = requireNotNull(_binding)
-    private val activityViewModel by activityViewModels<MyPageInformationViewModel>()
+    private val viewModel: WithdrawalDialogViewModel by viewModels()
+    private val withdrawalFeedbackDialogFragment by lazy { WithdrawalFeedbackDialogFragment.newInstance() }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -27,8 +31,9 @@ class WithdrawalDialogFragment : DialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        setClickEvents()
         trackEvent(getString(R.string.appear_withdrawal_modal))
+        setClickEvents()
+        setObservers()
     }
 
     private fun setClickEvents() {
@@ -38,7 +43,7 @@ class WithdrawalDialogFragment : DialogFragment() {
 
     private fun setWithdrawalTvClickEvent() {
         binding.tvWithdrawal.setOnClickListener {
-            activityViewModel.withdrawal()
+            viewModel.withdrawal()
         }
     }
 
@@ -48,9 +53,37 @@ class WithdrawalDialogFragment : DialogFragment() {
         }
     }
 
+    private fun setObservers() {
+        setWithdrawalObserver()
+    }
+
+    private fun setWithdrawalObserver() {
+        setWithdrawalSuccessObserver()
+        setWithdrawalErrorObserver()
+    }
+
+    private fun setWithdrawalErrorObserver() {
+        viewModel.withdrawalErrorResponse.observe(viewLifecycleOwner) { errorMessage ->
+            if (errorMessage == PublicString.NO_INTERNET_CONDITION_ERROR) requireContext().showNotTodoSnackBar(
+                binding.root, PublicString.NO_INTERNET_CONDITION_ERROR
+            )
+            else requireContext().showToast(errorMessage)
+        }
+    }
+
+    private fun setWithdrawalSuccessObserver() {
+        viewModel.withdrawalSuccessResponse.observe(viewLifecycleOwner) {
+            withdrawalFeedbackDialogFragment.show(
+                requireActivity().supportFragmentManager, withdrawalFeedbackDialogFragment.tag
+            )
+            trackEvent(getString(R.string.complete_withdrawal))
+            dismiss()
+        }
+    }
+
     override fun onDestroyView() {
-        super.onDestroyView()
         _binding = null
+        super.onDestroyView()
     }
 
     companion object {

--- a/app/src/main/java/kr/co/nottodo/presentation/mypage/view/WithdrawalFeedbackDialogFragment.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/mypage/view/WithdrawalFeedbackDialogFragment.kt
@@ -13,17 +13,17 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.DialogFragment
 import kr.co.nottodo.R
 import kr.co.nottodo.databinding.FragmentWithdrawalFeedbackDialogBinding
-import kr.co.nottodo.listeners.OnDialogDismissListener
+import kr.co.nottodo.listeners.OnWithdrawalDialogDismissListener
 
 class WithdrawalFeedbackDialogFragment : DialogFragment() {
     private var _binding: FragmentWithdrawalFeedbackDialogBinding? = null
     private val binding get() = _binding!!
-    private var onDialogDismissListener: OnDialogDismissListener? = null
+    private var onWithdrawalDialogDismissListener: OnWithdrawalDialogDismissListener? = null
     private lateinit var resultLauncher: ActivityResultLauncher<Intent>
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        onDialogDismissListener = context as? OnDialogDismissListener ?: throw TypeCastException(
+        onWithdrawalDialogDismissListener = context as? OnWithdrawalDialogDismissListener ?: throw TypeCastException(
             getString(
                 R.string.context_can_not_cast_as, getString(R.string.on_dialog_dismiss_listener)
             )
@@ -69,12 +69,12 @@ class WithdrawalFeedbackDialogFragment : DialogFragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
-        onDialogDismissListener = null
+        onWithdrawalDialogDismissListener = null
     }
 
     override fun onDismiss(dialog: DialogInterface) {
         super.onDismiss(dialog)
-        onDialogDismissListener?.onDialogDismiss() ?: throw NullPointerException(
+        onWithdrawalDialogDismissListener?.onWithdrawalDialogDismiss() ?: throw NullPointerException(
             getString(R.string._is_null, getString(R.string.on_dialog_dismiss_listener))
         )
     }

--- a/app/src/main/java/kr/co/nottodo/presentation/mypage/viewmodel/MyPageInformationNewViewModel.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/mypage/viewmodel/MyPageInformationNewViewModel.kt
@@ -1,0 +1,13 @@
+package kr.co.nottodo.presentation.mypage.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+class MyPageInformationNewViewModel : ViewModel() {
+    private val _isNotificationPermissionValid: MutableLiveData<Boolean> = MutableLiveData(false)
+    val isNotificationPermissionValid: LiveData<Boolean> = _isNotificationPermissionValid
+    fun setIsNotificationPermissionValid(isNotificationPermissionValid: Boolean) {
+        _isNotificationPermissionValid.value = isNotificationPermissionValid
+    }
+}

--- a/app/src/main/java/kr/co/nottodo/presentation/mypage/viewmodel/WithdrawalDialogViewModel.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/mypage/viewmodel/WithdrawalDialogViewModel.kt
@@ -1,0 +1,32 @@
+package kr.co.nottodo.presentation.mypage.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import kr.co.nottodo.data.remote.api.ServicePool.myPageService
+import kr.co.nottodo.util.PublicString.NO_INTERNET_CONDITION_ERROR
+import kr.co.nottodo.util.isConnectException
+
+class WithdrawalDialogViewModel : ViewModel() {
+
+    private val _withdrawalSuccessResponse: MutableLiveData<Boolean> = MutableLiveData()
+    val withdrawalSuccessResponse: LiveData<Boolean> = _withdrawalSuccessResponse
+
+    private val _withdrawalErrorResponse: MutableLiveData<String> = MutableLiveData()
+    val withdrawalErrorResponse: LiveData<String> = _withdrawalErrorResponse
+
+    fun withdrawal() {
+        viewModelScope.launch {
+            kotlin.runCatching {
+                myPageService.withdrawal()
+            }.fold(onSuccess = { response ->
+                _withdrawalSuccessResponse.value = response.isSuccessful
+            }, onFailure = { error ->
+                _withdrawalErrorResponse.value =
+                    if (error.isConnectException) NO_INTERNET_CONDITION_ERROR else error.message
+            })
+        }
+    }
+}

--- a/app/src/main/java/kr/co/nottodo/presentation/onboard/view/OnboardSixthFragment.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/onboard/view/OnboardSixthFragment.kt
@@ -43,6 +43,7 @@ class OnboardSixthFragment : Fragment() {
             trackEvent(getString(R.string.click_onboarding_next_5))
             SharedPreferences.setBoolean(DID_USER_WATCHED_ONBOARD, true)
             requireActivity().apply {
+                // TODO : 온보딩 끝난 후 LoginFragment로 이동 !
                 startActivity(Intent(context, LoginActivity::class.java))
                 if (!isFinishing) {
                     finish()

--- a/app/src/main/java/kr/co/nottodo/util/NotTodoAmplitude.kt
+++ b/app/src/main/java/kr/co/nottodo/util/NotTodoAmplitude.kt
@@ -20,7 +20,7 @@ object NotTodoAmplitude {
         )
     }
 
-    fun setUserId(userId: String) {
+    fun setAmplitudeUserId(userId: String) {
         amplitude.setUserId(userId)
     }
 

--- a/app/src/main/res/layout/fragment_my_page_information.xml
+++ b/app/src/main/res/layout/fragment_my_page_information.xml
@@ -9,7 +9,7 @@
 
         <variable
             name="vm"
-            type="kr.co.nottodo.presentation.mypage.viewmodel.MyPageInformationViewModel" />
+            type="kr.co.nottodo.presentation.mypage.viewmodel.MyPageInformationNewViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -30,7 +30,11 @@
     <fragment
         android:id="@+id/myPageInformationFragment"
         android:name="kr.co.nottodo.presentation.mypage.view.MyPageInformationFragment"
-        android:label="MyPageInformationFragment" />
+        android:label="MyPageInformationFragment">
+        <action
+            android:id="@+id/action_myPageInformationFragment_to_loginFragment"
+            app:destination="@id/loginFragment" />
+    </fragment>
     <fragment
         android:id="@+id/recommendMissionFragment"
         android:name="kr.co.nottodo.presentation.recommend.mission.view.RecommendMissionFragment"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph"
-    app:startDestination="@id/homeFragment">
+    app:startDestination="@id/loginFragment">
 
     <fragment
         android:id="@+id/homeFragment"
@@ -64,7 +64,7 @@
     <fragment
         android:id="@+id/loginFragment"
         android:name="kr.co.nottodo.presentation.login.view.LoginFragment"
-        android:label="LoginFragment" >
+        android:label="LoginFragment">
         <action
             android:id="@+id/action_loginFragment_to_homeFragment"
             app:destination="@id/homeFragment" />

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -61,4 +61,12 @@
             android:name="toAdditionFragmentUiModel"
             app:argType="kr.co.nottodo.presentation.recommend.model.ToAdditionUiModel" />
     </fragment>
+    <fragment
+        android:id="@+id/loginFragment"
+        android:name="kr.co.nottodo.presentation.login.view.LoginFragment"
+        android:label="LoginFragment" >
+        <action
+            android:id="@+id/action_loginFragment_to_homeFragment"
+            app:destination="@id/homeFragment" />
+    </fragment>
 </navigation>


### PR DESCRIPTION
## 👻 작업한 내용
### 로그인 프래그먼트 제작 및 적용

## 🎤 PR Point
- 회원 탈퇴 인터페이스를 구현하던 곳을 MyPageInformationActivity -> MainActivity로 변했습니다.
사유는 MyPageInfo...Activity를 더 이상 사용하지 않을 것이기에 context를 형변환하여 사용할 수 없기 때문입니다.
- MyPageInformationViewModel 에서 회원 탈퇴와 알람 권한 로직을 처리하였으나, 이를 나누어 MyPageInformationViewModel에서는 알람 권한에 대한 로직을, WithdrawalDialogViewModel에서 회원 탈퇴 로직을 관리합니다.
- 토큰 만료 시 LoginActivity가 아닌 MainActivity로 이동하며, fragment는 LoginFragment로 변경됩니다.
- LoginActivity를 더 이상 사용할 필요가 없기에, 시작점을 MainActivity로 수정하였습니다.
- myPage에서 로그아웃, 회원탈퇴 시 LoginFragment로 이동하며, LoginFragment에서는 뒤로 가기를 오버라이딩하여 popBackStack이 아닌 앱 종료 로직을 수행합니다.
## 📸 스크린샷

## 📮 관련 이슈
TODO : 온보딩을 navGraph에 추가하며 온보딩이 끝날 경우 LoginFragment로 이동시키겠습니다. #197 
- Resolved: #205 
