### PR TITLE
[FEAT] 알림 권한 교육용 모달, 공통 모달 순서 지정 및 버그 수정

### DIFF
--- a/app/src/main/java/kr/co/nottodo/data/local/SharedPreferences.kt
+++ b/app/src/main/java/kr/co/nottodo/data/local/SharedPreferences.kt
@@ -8,6 +8,7 @@ import androidx.security.crypto.MasterKey
 import kr.co.nottodo.BuildConfig
 import kr.co.nottodo.R
 import kr.co.nottodo.presentation.login.view.LoginFragment
+import kr.co.nottodo.util.PublicString.DID_USER_WATCHED_NOTIFICATION_PERMISSION_FRAGMENT
 import kr.co.nottodo.util.PublicString.STOP_WATCHING_COMMON_DIALOG
 
 object SharedPreferences {
@@ -50,9 +51,15 @@ object SharedPreferences {
     }
 
     fun clearForLogout() {
+        val tempForNotificationPermissionRequestFragment =
+            getBoolean(DID_USER_WATCHED_NOTIFICATION_PERMISSION_FRAGMENT)
         val tempForCommonDialog = getBoolean(STOP_WATCHING_COMMON_DIALOG)
         clear()
         setBoolean(LoginFragment.DID_USER_WATCHED_ONBOARD, true)
         setBoolean(STOP_WATCHING_COMMON_DIALOG, tempForCommonDialog)
+        setBoolean(
+            DID_USER_WATCHED_NOTIFICATION_PERMISSION_FRAGMENT,
+            tempForNotificationPermissionRequestFragment
+        )
     }
 }

--- a/app/src/main/java/kr/co/nottodo/presentation/home/view/HomeFragment.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/home/view/HomeFragment.kt
@@ -18,6 +18,7 @@ import kr.co.nottodo.listeners.OnFragmentChangedListener
 import kr.co.nottodo.presentation.home.viewmodel.HomeViewModel
 import kr.co.nottodo.util.NotTodoAmplitude.trackEvent
 import kr.co.nottodo.util.NotTodoAmplitude.trackEventWithProperty
+import kr.co.nottodo.util.PublicString
 import kr.co.nottodo.util.PublicString.DID_USER_WATCHED_NOTIFICATION_PERMISSION_FRAGMENT
 import kr.co.nottodo.view.calendar.monthly.util.convertToLocalDate
 import kr.co.nottodo.view.calendar.weekly.listener.OnWeeklyCalendarSwipeListener
@@ -67,6 +68,7 @@ class HomeFragment : Fragment(), DialogCloseListener {
         firstDayGet()
         navigateToNotificationPermissionRequestFragment()
         trackEvent(getString(R.string.view_home))
+        showCommonDialog()
     }
 
     private fun observerData() {
@@ -184,6 +186,11 @@ class HomeFragment : Fragment(), DialogCloseListener {
         ) {
             findNavController().navigate(R.id.action_homeFragment_to_notificationPermissionRequestDialogFragment)
         }
+    }
+
+    private fun showCommonDialog() {
+        if (SharedPreferences.getBoolean(PublicString.STOP_WATCHING_COMMON_DIALOG)) return
+        findNavController().navigate(R.id.action_homeFragment_to_commonDialogFragment)
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/kr/co/nottodo/presentation/home/view/NotificationPermissionRequestFragment.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/home/view/NotificationPermissionRequestFragment.kt
@@ -63,6 +63,7 @@ class NotificationPermissionRequestFragment :
             requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
         } else {
             SharedPreferences.setBoolean(DID_USER_CHOOSE_TO_BE_NOTIFIED, true)
+            findNavController().popBackStack()
         }
     }
 

--- a/app/src/main/java/kr/co/nottodo/presentation/login/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/login/viewmodel/LoginViewModel.kt
@@ -4,6 +4,9 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import kr.co.nottodo.data.remote.api.ServicePool.tokenService
 import kr.co.nottodo.data.remote.model.login.RequestTokenDto
@@ -12,9 +15,9 @@ import kr.co.nottodo.presentation.login.view.LoginActivity.Companion.KAKAO
 
 class LoginViewModel : ViewModel() {
 
-    private val _getTokenResult: MutableLiveData<ResponseTokenDto> = MutableLiveData()
-    val getTokenResult: LiveData<ResponseTokenDto>
-        get() = _getTokenResult
+    private val _getTokenResult: MutableSharedFlow<ResponseTokenDto> = MutableSharedFlow()
+    val getTokenResult: SharedFlow<ResponseTokenDto>
+        get() = _getTokenResult.asSharedFlow()
 
     private val _getErrorResult: MutableLiveData<String> = MutableLiveData()
     val getErrorResult: LiveData<String>
@@ -28,7 +31,7 @@ class LoginViewModel : ViewModel() {
                         socialToken = socialToken, fcmToken = fcmToken
                     )
                 )
-            }.fold(onSuccess = { _getTokenResult.value = it },
+            }.fold(onSuccess = { _getTokenResult.emit(it) },
                 onFailure = { _getErrorResult.value = it.message })
         }
     }

--- a/app/src/main/java/kr/co/nottodo/util/NavControllerExtension.kt
+++ b/app/src/main/java/kr/co/nottodo/util/NavControllerExtension.kt
@@ -1,0 +1,28 @@
+package kr.co.nottodo.util
+
+import android.os.Bundle
+import androidx.annotation.IdRes
+import androidx.navigation.NavController
+import androidx.navigation.NavDestination
+import androidx.navigation.NavGraph
+import androidx.navigation.NavOptions
+
+val NavController.startDestination: NavDestination
+    get() {
+        var startDestination: NavDestination = this.graph
+        while (startDestination is NavGraph) {
+            val graphStartDestination = startDestination
+            startDestination =
+                graphStartDestination.findNode(graphStartDestination.startDestinationId)
+                    ?: throw IllegalStateException("Failed Found Start Destination")
+        }
+        return startDestination
+    }
+
+fun NavController.navigateWithClearingBackstack(@IdRes resId: Int, args: Bundle? = null) {
+    val clearBackstackNavOptions =
+        NavOptions.Builder().setPopUpTo(this.startDestination.id, true).build()
+    this.navigate(
+        resId, args, clearBackstackNavOptions
+    )
+}

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -19,6 +19,9 @@
         <action
             android:id="@+id/action_homeFragment_to_notificationPermissionRequestDialogFragment"
             app:destination="@id/notificationPermissionRequestFragment" />
+        <action
+            android:id="@+id/action_homeFragment_to_commonDialogFragment"
+            app:destination="@id/commonDialogFragment" />
     </fragment>
     <fragment
         android:id="@+id/achieveFragment"
@@ -154,4 +157,8 @@
             android:id="@+id/action_onboardSixthFragment_to_loginFragment"
             app:destination="@id/loginFragment" />
     </fragment>
+    <dialog
+        android:id="@+id/commonDialogFragment"
+        android:name="kr.co.nottodo.presentation.common.view.CommonDialogFragment"
+        android:label="CommonDialogFragment" />
 </navigation>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -83,6 +83,9 @@
         <action
             android:id="@+id/action_loginFragment_to_onboardFirstFragment"
             app:destination="@id/onboardFirstFragment" />
+        <action
+            android:id="@+id/action_loginFragment_to_notificationPermissionRequestFragment"
+            app:destination="@id/notificationPermissionRequestFragment" />
     </fragment>
     <fragment
         android:id="@+id/modificationFragment"


### PR DESCRIPTION
## 👻 작업한 내용

- 알림 권한 교육용 모달, 공통 모달 순서 지정
-> 온보딩 -> 로그인 페이지 -> 로그인 완료 -> 알림 페이지 -> 네, 알겠어요 -> 알림 다이얼로그 등장 후 허용/낫허용 누르면 -> 홈 이동
- SDK 33 이하 기기에서 교육용 모달에서 버튼 이벤트 발생하지 않던 버그 수정

## 🎤 PR Point

## 📸 스크린샷
- SDK 33 이상(실기기, SDK 34)

https://github.com/DO-NOTTO-DO/AOS-NOTTODO/assets/108331578/f04c2efd-952f-45b1-a66d-bedc86a0d98b


- SDK 32 이하(Pixel 6, SDK 31)

https://github.com/DO-NOTTO-DO/AOS-NOTTODO/assets/108331578/1309254c-a2bd-4d24-b611-61935fcc4c78


## 📮 관련 이슈

- Resolved: #227
- Resolved: #223 
