### PR TITLE
16KB 메모리 페이지 크기 지원

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -112,8 +112,6 @@ dependencies {
     implementation 'androidx.multidex:multidex:2.0.1'
     // lottie
     implementation 'com.airbnb.android:lottie:6.0.0'
-    // koral : android gif drawable
-    implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.25'
     // google oss licenses
     implementation("com.google.android.gms:play-services-oss-licenses:17.0.1")
     // amplitude

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ android {
         applicationId "kr.co.nottodo"
         minSdk 26
         targetSdk 35
-        versionCode 16
+        versionCode 17
         versionName "1.1.0"
         multiDexEnabled true
 


### PR DESCRIPTION
## 👻 작업한 내용

- 16KB 메모리 페이지 크기 지원을 위한 네이티브 라이브러리 제거
  - `pl.droidsonroids.gif:android-gif-drawable:1.2.25` 라이브러리 제거
  - 사용하지 않는 GIF 리소스 파일(`img_onboard_two.gif`) 삭제
- 배포를 위해 versionCode 17로 업데이트

## 🎤 PR Point

Android 15부터 일부 기기에서 16KB 메모리 페이지 크기를 사용하게 되면서, 네이티브 라이브러리를 포함한 앱의 경우 호환성 문제가 발생할 수 있습니다.

이번 작업에서는:
1. **네이티브 라이브러리 제거**: android-gif-drawable 라이브러리가 네이티브 `.so` 파일(`libpl_droidsonroids_gif.so`)을 포함하고 있어 16KB 페이지 크기 지원 이슈의 원인이 되었습니다. 해당 라이브러리와 관련 리소스를 제거하여 문제를 해결했습니다.
2. **테스트 완료**: `unzip -l app/release/app-release.apk | grep "\.so"` 명령어로 네이티브 코드에 의존하지 않음을 확인했고, 16KB 페이지 환경에서 정상 설치 및 실행됨을 확인했습니다.
    <img width="760" height="106" alt="스크린샷 2025-11-10 오후 7 37 32" src="https://github.com/user-attachments/assets/20ee272f-63cc-4cb1-a654-e3eaa160206e" />

3. **버전 업데이트**: versionCode를 17로 증가시켜 새 버전을 배포할 준비를 완료했습니다.

이를 통해 16KB 메모리 페이지 크기를 사용하는 Android 15 기기에서도 앱이 정상적으로 동작합니다.

## 📮 관련 이슈

- Resolved: #264 
